### PR TITLE
Fix #23: Correct C++ ZMQ package name for Ubuntu 22.04

### DIFF
--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -29,7 +29,7 @@ jobs:
               build-essential \
               ca-certificates \
               cmake \
-              cppzmq-dev \
+              libcppzmq-dev \
               git \
               libasound2-dev \
               libvulkan-dev \


### PR DESCRIPTION
## 問題

PR #24 マージ後、arm64-release ワークフローが失敗していました。
原因: Ubuntu 22.04には `cppzmq-dev` というパッケージが存在しない。

## 修正内容

`cppzmq-dev` → `libcppzmq-dev` に修正

Ubuntu 22.04の正しいパッケージ名は `libcppzmq-dev` です。

## 検証

- apt-get installステップが成功するはず
- ビルドが正常に完了するはず
- GHCRへのイメージpushが成功するはず

Fixes #23