### PR TITLE
Fix #23: Remove libcppzmq-dev (not available on Ubuntu 22.04)

### DIFF
--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -29,7 +29,6 @@ jobs:
               build-essential \
               ca-certificates \
               cmake \
-              libcppzmq-dev \
               git \
               libasound2-dev \
               libvulkan-dev \


### PR DESCRIPTION
Ubuntu 22.04では libzmq3-dev パッケージに zmq.hpp が含まれています。 cppzmq-dev や libcppzmq-dev は Ubuntu 24.04以降でのみ利用可能です。

libzmq3-dev だけで十分です。

参考:
- Ubuntu 22.04 libzmq3-dev には /usr/include/zmq.hpp が含まれる
- cppzmq-dev は Ubuntu 24.04 (Noble) 以降でのみ利用可能