### PR TITLE
Fix #27: VkFFT TestSuite をビルド対象から外す

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,10 @@ if(ENABLE_VULKAN)
             GIT_REPOSITORY https://github.com/DTolm/VkFFT.git
             GIT_TAG v1.3.1
         )
-        FetchContent_MakeAvailable(vkfft)
+        FetchContent_GetProperties(vkfft)
+        if(NOT vkfft_POPULATED)
+            FetchContent_Populate(vkfft)
+        endif()
         target_compile_definitions(vulkan_upsampler PRIVATE USE_VKFFT=1 VKFFT_BACKEND=0)
         target_include_directories(vulkan_upsampler PRIVATE ${vkfft_SOURCE_DIR})
     endif()


### PR DESCRIPTION
## 変更内容\n- VkFFT を FetchContent で取得するが add_subdirectory しない形に変更\n- VkFFT の TestSuite/benchmark をビルド対象から外し、警告で CI が落ちるループを止める\n\n## 背景\nIssue #27 の CI 失敗対応。\n\n## 動作確認\n- pre-commit run --hook-stage pre-push（push 時に自動実行）