### PR TITLE
#29 docker-composeでWebサーバを自動起動

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
     environment:
       TOTTON_CONFIG_PATH: /var/lib/totton-dsp/config.json
       TOTTON_EQ_DIR: /var/lib/totton-dsp/eq
-      TOTTON_ZMQ_ENDPOINT: ipc:///tmp/totton_zmq.sock
-      TOTTON_ZMQ_PUB_ENDPOINT: ipc:///tmp/totton_zmq_pub.sock
+      TOTTON_ZMQ_ENDPOINT: tcp://0.0.0.0:5555
+      TOTTON_ZMQ_PUB_ENDPOINT: tcp://0.0.0.0:5556
       TOTTON_STATS_PATH: /tmp/gpu_upsampler_stats.json
       TOTTON_WEB_PORT: 8080
       TOTTON_ALSA_IN: ${TOTTON_ALSA_IN:-hw:0,0}
@@ -29,6 +29,35 @@ services:
       TOTTON_FILTER_DIR: ${TOTTON_FILTER_DIR:-/opt/totton-dsp/data/coefficients}
       TOTTON_FILTER_RATIO: ${TOTTON_FILTER_RATIO:-2}
       TOTTON_FILTER_PHASE: ${TOTTON_FILTER_PHASE:-min}
+    volumes:
+      - totton-dsp-data:/var/lib/totton-dsp
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+  totton-web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: totton-web
+    depends_on:
+      - totton-dsp
+    entrypoint:
+      - uvicorn
+      - web.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+    environment:
+      TOTTON_CONFIG_PATH: /var/lib/totton-dsp/config.json
+      TOTTON_EQ_DIR: /var/lib/totton-dsp/eq
+      TOTTON_ZMQ_ENDPOINT: tcp://totton-dsp:5555
+      TOTTON_ZMQ_PUB_ENDPOINT: tcp://totton-dsp:5556
+      TOTTON_STATS_PATH: /tmp/gpu_upsampler_stats.json
+      TOTTON_WEB_PORT: 8080
     volumes:
       - totton-dsp-data:/var/lib/totton-dsp
     ports:


### PR DESCRIPTION
## 概要\n- docker-compose 起動で Web サーバが確実に立ち上がるよう Web サービスを追加\n- ZMQ エンドポイントをコンテナ間 TCP に変更\n- ポート公開は Web 側に集約\n\n## 動作確認\n- git push 時の pre-push hooks を通過\n