### PR TITLE
Fix #31: docker compose の totton-web を GHCR イメージ参照に

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,13 @@ services:
         max-size: "10m"
         max-file: "3"
   totton-web:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # Use pre-built image from GHCR (recommended)
+    image: ghcr.io/michihitotakami/totton-rasp-gpu-dsp:latest
+
+    # Or build locally (uncomment the lines below and comment out the image line above)
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
     container_name: totton-web
     depends_on:
       - totton-dsp


### PR DESCRIPTION
## 変更内容\n- totton-web を GHCR イメージ参照に切り替え（デフォルトでローカル build されない）\n- ローカルビルド手順はコメントとして残す\n\n## 背景\nIssue #31 の再現手順で  がローカルビルドに走り失敗するため。\n\n## 動作確認\n- pre-commit run --hook-stage pre-push（push 時に自動実行）