### PR TITLE
Fix #33: Docker イメージに scripts を含める

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY build/alsa_streamer /usr/local/bin/alsa_streamer
 COPY build/zmq_control_server /usr/local/bin/zmq_control_server
 COPY web /opt/totton-dsp/web
 COPY data /opt/totton-dsp/data
+COPY scripts /opt/totton-dsp/scripts
 COPY docker/entrypoint.sh /usr/local/bin/totton-entrypoint.sh
 
 RUN pip3 install --no-cache-dir \


### PR DESCRIPTION
## 変更内容\n- Docker イメージに scripts/ を追加コピーし、web の modern_target 依存を解決\n\n## 背景\nIssue #33: totton-web が ModuleNotFoundError: No module named 'modern_target' で起動失敗するため。\n\n## 動作確認\n- pre-commit run --hook-stage pre-push（push 時に自動実行）