### PR TITLE
Fix #35: arm64 CI のビルド並列数を抑制

### DIFF
--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -43,7 +43,8 @@ jobs:
               -DENABLE_OPT=0 \
               -DENABLE_ALSA=ON \
               -DENABLE_ZMQ=ON
-            cmake --build build -j$(nproc)
+            # QEMU 環境のリンク時クラッシュ回避のため並列数を抑える
+            cmake --build build -j2
 
       - name: Package release bundle
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## 変更内容\n- arm64 CI のビルド並列数を j2 に固定\n- QEMU 環境でのリンク時 Segfault を回避\n\n## 背景\nIssue #35: zmq_control_server のリンク中に Segmentation fault が発生するため。\n\n## 動作確認\n- pre-commit run --hook-stage pre-push（push 時に自動実行）