### PR TITLE
#37 arm64 CI の GCC ICE 回避

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,15 @@ option(ENABLE_VULKAN "Enable Vulkan upsampler" ON)
 option(USE_VKFFT "Use VkFFT backend when Vulkan is enabled" ON)
 option(ENABLE_ALSA "Enable ALSA streaming app" ON)
 option(ENABLE_ZMQ "Enable ZeroMQ control server" ON)
+option(ENABLE_OPT "Enable compiler optimizations" ON)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT ENABLE_OPT)
+    # Disable optimization when running under emulation to avoid GCC ICE.
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-O0>)
+endif()
 
 add_library(vulkan_upsampler
     src/vulkan/vulkan_streaming_upsampler.cpp


### PR DESCRIPTION
## 概要\n- GitHub Actions arm64 ビルドで発生している GCC 11 の ICE を回避するため、CMake の ENABLE_OPT を有効化し -DENABLE_OPT=0 が効くようにしました。\n\n## 動作確認\n- -- Configuring done (1.2s)
-- Generating done (0.1s)
-- Build files have been written to: /home/michihito/Working/totton-rasp-gpu-dsp/worktrees/37-fix-arm64-ci/build\n- [  6%] Built target vulkan_upsampler
[ 12%] Built target zmq_server_e2e
[ 21%] Built target auto_negotiation
[ 27%] Built target alsa_streamer_e2e
[ 30%] Building CXX object CMakeFiles/audio_eq.dir/src/audio/eq_parser.cpp.o
[ 39%] Built target alsa_utils
[ 45%] Built target zmq_command_server
[ 51%] Built target auto_negotiation_smoke
[ 54%] Building CXX object CMakeFiles/alsa_common_smoke.dir/tests/cpp/test_alsa_common.cpp.o
[ 57%] Building CXX object CMakeFiles/alsa_filter_selector_smoke.dir/tests/cpp/test_alsa_filter_selector.cpp.o
[ 60%] Building CXX object CMakeFiles/zmq_control_server.dir/src/zmq/zmq_server_main.cpp.o
[ 63%] Building CXX object CMakeFiles/alsa_streamer.dir/src/alsa/alsa_streamer_main.cpp.o
[ 66%] Building CXX object CMakeFiles/upsampler_smoke.dir/tests/cpp/test_vulkan_upsampler.cpp.o
[ 69%] Linking CXX executable alsa_common_smoke
[ 72%] Linking CXX executable alsa_filter_selector_smoke
[ 72%] Built target alsa_filter_selector_smoke
[ 72%] Built target alsa_common_smoke
[ 75%] Linking CXX executable zmq_control_server
[ 75%] Built target zmq_control_server
[ 78%] Linking CXX executable upsampler_smoke
[ 81%] Linking CXX executable alsa_streamer
[ 81%] Built target upsampler_smoke
[ 81%] Built target alsa_streamer
[ 84%] Linking CXX static library libaudio_eq.a
[ 87%] Built target audio_eq
[ 93%] Building CXX object CMakeFiles/eq_parser_smoke.dir/tests/cpp/test_eq_parser_smoke.cpp.o
[ 93%] Building CXX object CMakeFiles/eq_to_fir_smoke.dir/tests/cpp/test_eq_to_fir_smoke.cpp.o
[ 96%] Linking CXX executable eq_parser_smoke
[100%] Linking CXX executable eq_to_fir_smoke
[100%] Built target eq_parser_smoke
[100%] Built target eq_to_fir_smoke\n