### PR TITLE
Fix #45: Add missing fields to filter JSON metadata

### DIFF
--- a/scripts/filters/generate_filter.py
+++ b/scripts/filters/generate_filter.py
@@ -200,6 +200,17 @@ class FilterExporter:
         print(f"  保存: {header_path}")
 
     def _export_metadata(self, metadata: dict[str, Any], base_name: str) -> None:
+        # 必須フィールドを追加
+        actual_taps = metadata.get("n_taps_actual", self.config.final_taps)
+        fft_size = 2 ** int(np.ceil(np.log2(actual_taps)))
+        block_size = fft_size - (actual_taps - 1)
+
+        metadata["coefficients_bin"] = f"{base_name}.bin"
+        metadata["taps"] = actual_taps
+        metadata["fft_size"] = fft_size
+        metadata["block_size"] = block_size
+        metadata["upsample_factor"] = self.config.upsample_ratio
+
         metadata_path = self.output_dir / f"{base_name}.json"
 
         # Convert numpy types to native Python types for JSON serialization


### PR DESCRIPTION
## 概要

`alsa_streamer` が起動時にフィルターJSONを読み込む際に必要な必須フィールドを追加します。

## 変更内容

### 修正ファイル

`scripts/filters/generate_filter.py` の `FilterExporter._export_metadata()` メソッドを修正し、以下のフィールドを追加：

- `coefficients_bin`: バイナリファイル名（例: `filter_44k_16x_2m_min_phase.bin`）
- `taps`: タップ数（actual_taps）
- `fft_size`: FFTサイズ（2のべき乗）
- `block_size`: ブロックサイズ（`fft_size - (taps - 1)` で計算）
- `upsample_factor`: アップサンプル倍率

### 実装詳細

```python
actual_taps = metadata.get("n_taps_actual", self.config.final_taps)
fft_size = 2 ** int(np.ceil(np.log2(actual_taps)))
block_size = fft_size - (actual_taps - 1)

metadata["coefficients_bin"] = f"{base_name}.bin"
metadata["taps"] = actual_taps
metadata["fft_size"] = fft_size
metadata["block_size"] = block_size
metadata["upsample_factor"] = self.config.upsample_ratio
```

## 検証

- [x] コードの修正完了
- [x] pre-commitフック全て通過
- [ ] 新規生成されるJSONに5つのフィールドが含まれることを確認（後続で実施）
- [ ] `alsa_streamer` がフィルターを正常にロード可能（後続で実施）

## 関連Issue

Closes #45