### PR TITLE
Fix #59: Docker build context includes binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 # Build artifacts
-build/
+build/*
+!build/alsa_streamer
+!build/zmq_control_server
 *.o
 *.so
 *.a


### PR DESCRIPTION
## 概要
- Docker ビルドで必要な build/ のバイナリが .dockerignore で除外されていたため、必要ファイルのみコンテキストに含めるよう修正

## 変更点
- `.dockerignore` の build ルールを調整し、`build/alsa_streamer` と `build/zmq_control_server` を許可

## 動作確認
- pre-push hooks (build/ctest/diff-based/e2e など) を通過

Fixes #59
