### PR TITLE
#67 デバイス発見時もZMQサーバーを継続

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -108,4 +108,5 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-wait -n "$ZMQ_PID" "$ALSA_PID" "$WEB_PID"
+# Keep container alive as long as control plane is running.
+wait "$ZMQ_PID"


### PR DESCRIPTION
## 概要
- alsa_streamer が落ちても zmq_control_server を継続させるため entrypoint の wait を変更

## テスト
- pre-commit run --hook-stage pre-push