### PR TITLE
#75 PrepareFilterのレート自動検出でperiodFramesのデフォルトを補完

### DIFF
--- a/src/alsa/alsa_common.cpp
+++ b/src/alsa/alsa_common.cpp
@@ -244,6 +244,9 @@ std::optional<AlsaHandle>
 OpenCaptureAutoRate(const std::string &device, snd_pcm_format_t format,
                     unsigned int channels, unsigned int requestedRate,
                     snd_pcm_uframes_t period, snd_pcm_uframes_t buffer) {
+  if (period == 0) {
+    period = 1024;
+  }
   if (requestedRate != 0) {
     return OpenPcm(device, SND_PCM_STREAM_CAPTURE, format, channels,
                    requestedRate, period, buffer);


### PR DESCRIPTION
## 概要
- OpenCaptureAutoRateでperiodFramesが0の場合に1024へフォールバックし、プレビュー時のALSAエラーを回避

## テスト
- pre-commit run --hook-stage pre-push（git pushで実行）

Relates to #75