### PR TITLE
#85 i18n対応

### DIFF
--- a/web/i18n.py
+++ b/web/i18n.py
@@ -1,0 +1,191 @@
+"""Simple i18n helpers for the web UI."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+from fastapi import Request
+
+DEFAULT_LOCALE = "en"
+SUPPORTED_LOCALES = {"en"}
+
+TRANSLATIONS: Dict[str, Dict[str, str]] = {
+    "en": {
+        "app_title": "Totton Audio Control",
+        "nav_title": "Navigation",
+        "nav_eq_settings": "EQ Settings",
+        "nav_alsa_settings": "ALSA Settings",
+        "eq_page_title": "Totton Audio Control",
+        "eq_page_subtitle": "EQ control, phase switching, and live DSP status.",
+        "section_system_status": "System Status",
+        "label_state": "State",
+        "label_input_rate": "Input Rate",
+        "label_output_rate": "Output Rate",
+        "label_xrun_total": "XRUN Total",
+        "label_uptime": "Uptime",
+        "label_phase": "Phase",
+        "status_running": "RUNNING",
+        "status_stopped": "STOPPED",
+        "section_dsp_controls": "DSP Controls",
+        "btn_minimum": "Minimum",
+        "btn_linear": "Linear",
+        "btn_reload": "Reload",
+        "btn_soft_reset": "Soft Reset",
+        "btn_refresh_status": "Refresh Status",
+        "section_active_profile": "Active Profile",
+        "label_none": "None",
+        "text_profile_active": "Profile is active",
+        "text_profile_inactive": "No EQ profile active",
+        "badge_on": "ON",
+        "badge_off": "OFF",
+        "label_source": "Source",
+        "label_modern_target": "Modern Target",
+        "label_kb5000": "KB5000_7",
+        "btn_deactivate_eq": "Deactivate EQ",
+        "section_upload_validate": "Upload & Validate",
+        "label_eq_profile_file": "EQ Profile (.txt)",
+        "btn_validate": "Validate",
+        "btn_import": "Import",
+        "text_validation_passed": "Validation passed:",
+        "text_filters_suffix": "filters.",
+        "label_preamp_from_file": "Preamp (from file)",
+        "label_recommended_preamp": "Recommended Preamp (Headroom)",
+        "section_opra_search": "OPRA Headphone Search",
+        "btn_apply_opra": "Apply OPRA EQ",
+        "text_eq_data_prefix": "EQ data:",
+        "text_opra_project": "OPRA Project",
+        "text_opra_license_suffix": "(CC BY-SA 4.0)",
+        "section_saved_profiles": "Saved Profiles",
+        "text_filters_count": "filters",
+        "btn_activate": "Activate",
+        "text_no_saved_profiles": "No saved profiles yet.",
+        "section_opra_sync": "OPRA Sync",
+        "label_status": "Status",
+        "label_current_commit": "Current Commit",
+        "label_previous_commit": "Previous Commit",
+        "label_downloaded_at": "Downloaded At",
+        "label_last_error": "Last Error",
+        "label_source_target": "Source / Target",
+        "placeholder_latest_or_sha": "latest or commit SHA",
+        "btn_check_updates": "Check Updates",
+        "btn_update": "Update",
+        "btn_rollback": "Rollback",
+        "opra_status_running": "Running",
+        "opra_status_ready": "Ready",
+        "opra_status_failed": "Failed",
+        "opra_status_idle": "Idle",
+        "opra_badge_running": "RUNNING",
+        "opra_badge_ready": "READY",
+        "opra_badge_failed": "FAILED",
+        "opra_badge_idle": "IDLE",
+        "text_dash": "—",
+        "label_unknown": "unknown",
+        "text_latest_available": "Latest available: {value}",
+        "confirm_start_opra_update": "Start OPRA update ({target})?",
+        "confirm_opra_rollback": "Rollback OPRA database to previous version?",
+        "message_opra_update_started": "OPRA update started",
+        "message_opra_rollback_started": "OPRA rollback started",
+        "error_failed_check_updates": "Failed to check updates",
+        "error_failed_start_update": "Failed to start update",
+        "error_failed_start_rollback": "Failed to start rollback",
+        "error_search_failed": "Search failed",
+        "error_no_eq_profile_selected": "No EQ profile selected",
+        "error_failed_apply_opra": "Failed to apply OPRA EQ",
+        "message_opra_eq_applied": "OPRA EQ applied",
+        "error_upload_failed": "Upload failed",
+        "error_phase_update_failed": "Phase update failed",
+        "message_phase_updated": "Phase updated",
+        "message_reload_requested": "Reload requested",
+        "message_soft_reset_requested": "Soft reset requested",
+        "error_command_failed": "Command failed",
+        "unit_hz": "Hz",
+        "unit_hour_short": "h",
+        "unit_minute_short": "m",
+        "unit_second_short": "s",
+        "label_search_headphones": "Search Headphones",
+        "placeholder_search_headphones": "e.g. HD650, DT770, AirPods...",
+        "label_eq_variation": "EQ Variation",
+        "label_opra_modern_target": "Modern Target (KB5000_7)",
+        "text_opra_modern_target": "Correct to the latest target curve.",
+        "alsa_page_title": "ALSA Device Settings",
+        "alsa_page_subtitle": "Select capture/playback devices and persist settings.",
+        "section_device_selection": "Device Selection",
+        "label_input_device": "Input Device",
+        "label_output_device": "Output Device",
+        "notice_devices_empty": "Device list is empty or unavailable. Ensure the DSP daemon is running.",
+        "section_stream_parameters": "Stream Parameters",
+        "label_sample_rate": "Sample Rate (Hz)",
+        "placeholder_auto": "Auto",
+        "label_channels": "Channels",
+        "placeholder_channels_default": "2",
+        "label_format": "Format",
+        "label_period_frames": "Period Frames",
+        "label_buffer_frames": "Buffer Frames",
+        "section_filter_settings": "Filter Settings",
+        "label_upsample_ratio": "Upsample Ratio",
+        "label_phase_type": "Phase Type",
+        "label_filter_directory": "Filter Directory",
+        "placeholder_filter_directory": "/opt/totton-dsp/data/coefficients",
+        "section_apply_settings": "Apply Settings",
+        "btn_save_apply": "Save & Apply",
+        "btn_reload_devices": "Reload Devices",
+        "btn_refresh_config": "Refresh Config",
+        "ratio_1x_bypass": "1x (Bypass)",
+        "ratio_2x": "2x",
+        "ratio_4x": "4x",
+        "ratio_8x": "8x",
+        "ratio_16x": "16x",
+        "phase_minimum": "Minimum",
+        "phase_linear": "Linear",
+        "error_failed_load_devices": "Failed to load devices",
+        "error_failed_load_config": "Failed to load config",
+        "error_failed_save_config": "Failed to save config",
+        "message_saved_restart_required": "Saved. Restart required to apply ALSA changes.",
+        "message_saved_applied": "Saved and applied.",
+    }
+}
+
+
+def normalize_locale(value: str | None) -> str | None:
+    if not value:
+        return None
+    token = value.split(",")[0].split(";")[0].strip().lower()
+    if not token:
+        return None
+    return token.replace("_", "-")
+
+
+def pick_locale(request: Request) -> str:
+    candidates = [
+        request.query_params.get("lang"),
+        request.cookies.get("lang"),
+        request.headers.get("accept-language"),
+    ]
+    for candidate in candidates:
+        normalized = normalize_locale(candidate)
+        if not normalized:
+            continue
+        base = normalized.split("-")[0]
+        if base in SUPPORTED_LOCALES:
+            return base
+    return DEFAULT_LOCALE
+
+
+def get_translations(locale: str) -> Dict[str, str]:
+    return TRANSLATIONS.get(locale, TRANSLATIONS[DEFAULT_LOCALE])
+
+
+def build_context(request: Request) -> Dict[str, object]:
+    locale = pick_locale(request)
+    translations = get_translations(locale)
+
+    def t(key: str) -> str:
+        return translations.get(key, key)
+
+    translations_json = json.dumps(translations, ensure_ascii=True)
+    return {
+        "locale": locale,
+        "t": t,
+        "translations_json": translations_json,
+    }

--- a/web/routers/ui.py
+++ b/web/routers/ui.py
@@ -6,6 +6,8 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from ..i18n import build_context
+
 TEMPLATES = Jinja2Templates(directory=str(Path(__file__).parent.parent / "templates"))
 
 router = APIRouter(tags=["ui"])
@@ -14,10 +16,12 @@ router = APIRouter(tags=["ui"])
 @router.get("/", response_class=HTMLResponse)
 async def eq_settings(request: Request):
     """Render EQ settings page."""
-    return TEMPLATES.TemplateResponse("pages/eq_settings.html", {"request": request})
+    context = {"request": request, **build_context(request)}
+    return TEMPLATES.TemplateResponse("pages/eq_settings.html", context)
 
 
 @router.get("/settings", response_class=HTMLResponse)
 async def alsa_settings(request: Request):
     """Render ALSA settings page."""
-    return TEMPLATES.TemplateResponse("pages/settings.html", {"request": request})
+    context = {"request": request, **build_context(request)}
+    return TEMPLATES.TemplateResponse("pages/settings.html", context)

--- a/web/templates/components/opra_search.html
+++ b/web/templates/components/opra_search.html
@@ -14,9 +14,9 @@ Requirements:
 
 {{ forms.text_input(
   'opraSearch',
-  'Search Headphones',
+  t('label_search_headphones'),
   'opra.searchQuery',
-  placeholder='e.g. HD650, DT770, AirPods...',
+  placeholder=t('placeholder_search_headphones'),
   attrs='@input="searchOPRA" class="search-input"'
 ) }}
 
@@ -34,7 +34,7 @@ Requirements:
   <div class="opra-selected-vendor" x-text="opra.selected?.vendor?.name || opra.selected?.vendor"></div>
 
   <div class="form-group" style="margin-top: 12px;" x-show="opra.eqProfiles.length > 0">
-    <label for="opraEqSelect">EQ Variation</label>
+    <label for="opraEqSelect">{{ t('label_eq_variation') }}</label>
     <select id="opraEqSelect" x-model="opra.selectedEqId">
       <template x-for="eq in opra.eqProfiles" :key="eq.id">
         <option :value="eq.id" x-text="eq.details || eq.id"></option>
@@ -44,9 +44,9 @@ Requirements:
 
   <label class="checkbox-label" style="margin-top: 12px;">
     <input type="checkbox" x-model="opra.useModernTarget">
-    <span>Modern Target (KB5000_7)</span>
+    <span>{{ t('label_opra_modern_target') }}</span>
   </label>
   <div class="info-text" style="margin-left: 24px;">
-    Correct to the latest target curve.
+    {{ t('text_opra_modern_target') }}
   </div>
 </div>

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -1,10 +1,10 @@
 {% import "components/card_panel.html" as panels %}
 <!doctype html>
-<html lang="en">
+<html lang="{{ locale }}">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Totton Audio Control</title>
+    <title>{{ t('app_title') }}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -13,15 +13,29 @@
     />
     <link rel="stylesheet" href="/static/app.css" />
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <script>
+      window.__translations = {{ translations_json | safe }};
+      window.t = function(key, params) {
+        var text = window.__translations[key] || key;
+        if (!params) {
+          return text;
+        }
+        Object.keys(params).forEach(function(paramKey) {
+          var token = '{' + paramKey + '}';
+          text = text.split(token).join(String(params[paramKey]));
+        });
+        return text;
+      };
+    </script>
   </head>
   <body>
     <div class="background"></div>
     <main class="layout">
       <aside class="sidebar">
-        {% call panels.card_panel("Navigation") %}
+        {% call panels.card_panel(t('nav_title')) %}
           <nav class="nav-list">
-            <a class="nav-link {% if request.url.path == '/' %}is-active{% endif %}" href="/">EQ Settings</a>
-            <a class="nav-link {% if request.url.path == '/settings' %}is-active{% endif %}" href="/settings">ALSA Settings</a>
+            <a class="nav-link {% if request.url.path == '/' %}is-active{% endif %}" href="/">{{ t('nav_eq_settings') }}</a>
+            <a class="nav-link {% if request.url.path == '/settings' %}is-active{% endif %}" href="/settings">{{ t('nav_alsa_settings') }}</a>
           </nav>
         {% endcall %}
       </aside>

--- a/web/templates/pages/eq_settings.html
+++ b/web/templates/pages/eq_settings.html
@@ -7,56 +7,56 @@
 {% block content %}
 <div x-data="eqApp()" x-init="init()">
   <header class="page-header">
-    <h1 class="page-title">Totton Audio Control</h1>
-    <p class="page-subtitle">EQ control, phase switching, and live DSP status.</p>
+    <h1 class="page-title">{{ t('eq_page_title') }}</h1>
+    <p class="page-subtitle">{{ t('eq_page_subtitle') }}</p>
   </header>
 
   <div class="grid grid-2">
-    {% call panels.card_panel("System Status") %}
+    {% call panels.card_panel(t('section_system_status')) %}
       <div class="info-row">
         <div>
-          <div class="muted">State</div>
+          <div class="muted">{{ t('label_state') }}</div>
           <div class="mono" x-text="status.state"></div>
         </div>
-        <span class="badge" :class="status.daemon_running ? 'badge-on' : 'badge-off'" x-text="status.daemon_running ? 'RUNNING' : 'STOPPED'"></span>
+        <span class="badge" :class="status.daemon_running ? 'badge-on' : 'badge-off'" x-text="status.daemon_running ? t('status_running') : t('status_stopped')"></span>
       </div>
       <div class="info-row">
-        <div class="muted">Input Rate</div>
+        <div class="muted">{{ t('label_input_rate') }}</div>
         <div class="mono" x-text="formatRate(status.input_rate)"></div>
       </div>
       <div class="info-row">
-        <div class="muted">Output Rate</div>
+        <div class="muted">{{ t('label_output_rate') }}</div>
         <div class="mono" x-text="formatRate(status.output_rate)"></div>
       </div>
       <div class="info-row">
-        <div class="muted">XRUN Total</div>
+        <div class="muted">{{ t('label_xrun_total') }}</div>
         <div class="mono" x-text="status.xrun_total"></div>
       </div>
       <div class="info-row" x-show="status.uptime_ms !== null">
-        <div class="muted">Uptime</div>
+        <div class="muted">{{ t('label_uptime') }}</div>
         <div class="mono" x-text="formatUptime(status.uptime_ms)"></div>
       </div>
       <div class="info-row" x-show="status.phase_type">
-        <div class="muted">Phase</div>
+        <div class="muted">{{ t('label_phase') }}</div>
         <div class="mono" x-text="status.phase_type"></div>
       </div>
     {% endcall %}
 
-    {% call panels.card_panel("DSP Controls") %}
+    {% call panels.card_panel(t('section_dsp_controls')) %}
       <div class="info-row">
         <div>
-          <div class="muted">Phase</div>
+          <div class="muted">{{ t('label_phase') }}</div>
           <div class="mono" x-text="phaseType"></div>
         </div>
         <div class="profile-actions">
-          {{ buttons.btn_primary('Minimum', click="setPhase('minimum')", disabled="actionPending || phaseType === 'minimum'", attrs=":class=\"phaseType === 'minimum' ? '' : 'btn-secondary'\"") }}
-          {{ buttons.btn_primary('Linear', click="setPhase('linear')", disabled="actionPending || phaseType === 'linear'", attrs=":class=\"phaseType === 'linear' ? '' : 'btn-secondary'\"") }}
+          {{ buttons.btn_primary(t('btn_minimum'), click="setPhase('minimum')", disabled="actionPending || phaseType === 'minimum'", attrs=":class=\"phaseType === 'minimum' ? '' : 'btn-secondary'\"") }}
+          {{ buttons.btn_primary(t('btn_linear'), click="setPhase('linear')", disabled="actionPending || phaseType === 'linear'", attrs=":class=\"phaseType === 'linear' ? '' : 'btn-secondary'\"") }}
         </div>
       </div>
       <div class="profile-actions" style="margin-top: 12px;">
-        {{ buttons.btn_primary('Reload', click='requestReload()', disabled='actionPending') }}
-        {{ buttons.btn_primary('Soft Reset', click='requestSoftReset()', disabled='actionPending', extra_class='btn-secondary') }}
-        {{ buttons.btn_primary('Refresh Status', click='fetchStatus()', disabled='actionPending', extra_class='btn-secondary') }}
+        {{ buttons.btn_primary(t('btn_reload'), click='requestReload()', disabled='actionPending') }}
+        {{ buttons.btn_primary(t('btn_soft_reset'), click='requestSoftReset()', disabled='actionPending', extra_class='btn-secondary') }}
+        {{ buttons.btn_primary(t('btn_refresh_status'), click='fetchStatus()', disabled='actionPending', extra_class='btn-secondary') }}
       </div>
       <div class="notice success" x-show="actionMessage" x-text="actionMessage" style="margin-top: 16px;"></div>
       <div class="notice error" x-show="actionError" x-text="actionError" style="margin-top: 16px;"></div>
@@ -64,40 +64,40 @@
   </div>
 
   <div class="grid grid-2">
-    {% call panels.card_panel("Active Profile") %}
+    {% call panels.card_panel(t('section_active_profile')) %}
       <div class="info-row">
         <div>
-          <div class="mono" x-text="activeEq.name || 'None'"></div>
-          <div class="muted" x-text="activeEq.active ? 'Profile is active' : 'No EQ profile active'"></div>
+          <div class="mono" x-text="activeEq.name || t('label_none')"></div>
+          <div class="muted" x-text="activeEq.active ? t('text_profile_active') : t('text_profile_inactive')"></div>
         </div>
-        <span class="badge" :class="activeEq.active ? 'badge-on' : 'badge-off'" x-text="activeEq.active ? 'ON' : 'OFF'"></span>
+        <span class="badge" :class="activeEq.active ? 'badge-on' : 'badge-off'" x-text="activeEq.active ? t('badge_on') : t('badge_off')"></span>
       </div>
       <div class="info-row" x-show="activeEq.active && activeEq.source_type">
-        <div class="muted">Source</div>
+        <div class="muted">{{ t('label_source') }}</div>
         <div class="mono" x-text="activeEq.source_type"></div>
       </div>
       <div class="info-row" x-show="activeEq.active && activeEq.has_modern_target">
-        <div class="muted">Modern Target</div>
-        <div class="badge badge-warning">KB5000_7</div>
+        <div class="muted">{{ t('label_modern_target') }}</div>
+        <div class="badge badge-warning">{{ t('label_kb5000') }}</div>
       </div>
       <div class="notice warning" x-show="activeEq.error" x-text="activeEq.error"></div>
       <div class="profile-actions" style="margin-top: 16px;">
-        {{ buttons.btn_primary('Deactivate EQ', click='deactivateEq()', disabled='!activeEq.active', extra_class='btn-secondary') }}
+        {{ buttons.btn_primary(t('btn_deactivate_eq'), click='deactivateEq()', disabled='!activeEq.active', extra_class='btn-secondary') }}
       </div>
     {% endcall %}
 
-    {% call panels.card_panel("Upload & Validate") %}
+    {% call panels.card_panel(t('section_upload_validate')) %}
       <div class="form-group">
-        <label for="eqFile">EQ Profile (.txt)</label>
+        <label for="eqFile">{{ t('label_eq_profile_file') }}</label>
         <input id="eqFile" type="file" accept=".txt" @change="handleFile($event)">
       </div>
       <div class="profile-actions">
-        {{ buttons.btn_primary('Validate', click='validateUpload()', disabled='!upload.file') }}
-        {{ buttons.btn_primary('Import', click='importProfile()', disabled='!upload.file') }}
+        {{ buttons.btn_primary(t('btn_validate'), click='validateUpload()', disabled='!upload.file') }}
+        {{ buttons.btn_primary(t('btn_import'), click='importProfile()', disabled='!upload.file') }}
       </div>
 
       <div class="notice" x-show="validation && validation.valid">
-        Validation passed: <span class="mono" x-text="validation.filter_count"></span> filters.
+        {{ t('text_validation_passed') }} <span class="mono" x-text="validation.filter_count"></span> {{ t('text_filters_suffix') }}
       </div>
       <div class="notice error" x-show="validation && validation.errors.length">
         <template x-for="err in validation.errors" :key="err">
@@ -112,74 +112,74 @@
 
       <div x-show="validation && validation.preamp_db !== null" style="margin-top: 16px;">
         <div class="info-row">
-          <div class="muted">Preamp (from file)</div>
+          <div class="muted">{{ t('label_preamp_from_file') }}</div>
           <div class="mono" x-text="validation.preamp_db + ' dB'"></div>
         </div>
-        {{ sliders.slider_input(min=-30, max=0, step=0.1, model='recommendedPreamp', disabled='true', label='Recommended Preamp (Headroom)', id='recommendedPreamp') }}
+        {{ sliders.slider_input(min=-30, max=0, step=0.1, model='recommendedPreamp', disabled='true', label=t('label_recommended_preamp'), id='recommendedPreamp') }}
       </div>
     {% endcall %}
   </div>
 
-  {% call panels.card_panel("OPRA Headphone Search") %}
+  {% call panels.card_panel(t('section_opra_search')) %}
     {% include 'components/opra_search.html' %}
     <div class="profile-actions" style="margin-top: 12px;">
-      {{ buttons.btn_primary('Apply OPRA EQ', icon='✓', click='applyOPRA()', disabled='!opra.selected || opraActionPending') }}
+      {{ buttons.btn_primary(t('btn_apply_opra'), icon='✓', click='applyOPRA()', disabled='!opra.selected || opraActionPending') }}
     </div>
     <div class="notice success" x-show="opraMessage" x-text="opraMessage" style="margin-top: 12px;"></div>
     <div class="notice error" x-show="opraError" x-text="opraError" style="margin-top: 12px;"></div>
     <div class="opra-license" style="margin-top: 16px;">
-      EQ data: <a href="https://github.com/opra-project/OPRA" target="_blank" rel="noopener noreferrer">OPRA Project</a> (CC BY-SA 4.0)
+      {{ t('text_eq_data_prefix') }} <a href="https://github.com/opra-project/OPRA" target="_blank" rel="noopener noreferrer">{{ t('text_opra_project') }}</a> {{ t('text_opra_license_suffix') }}
     </div>
   {% endcall %}
 
-  {% call panels.card_panel("Saved Profiles") %}
+  {% call panels.card_panel(t('section_saved_profiles')) %}
     <div class="profile-list" x-show="profiles.length">
       <template x-for="profile in profiles" :key="profile.name">
         <div class="profile-item">
           <div>
             <div class="mono" x-text="profile.name"></div>
-            <div class="muted" x-text="profile.filter_count + ' filters'"></div>
+            <div class="muted" x-text="profile.filter_count + ' ' + t('text_filters_count')"></div>
           </div>
           <div class="profile-actions">
-            {{ buttons.btn_primary('Activate', click="activateProfile(profile.name)", disabled="activeEq.name === profile.name") }}
+            {{ buttons.btn_primary(t('btn_activate'), click="activateProfile(profile.name)", disabled="activeEq.name === profile.name") }}
           </div>
         </div>
       </template>
     </div>
-    <div class="notice" x-show="!profiles.length">No saved profiles yet.</div>
+    <div class="notice" x-show="!profiles.length">{{ t('text_no_saved_profiles') }}</div>
   {% endcall %}
 
-  {% call panels.card_panel("OPRA Sync") %}
+  {% call panels.card_panel(t('section_opra_sync')) %}
     <div class="info-row">
       <div>
-        <div class="muted">Status</div>
+        <div class="muted">{{ t('label_status') }}</div>
         <div class="mono" x-text="formatOpraStatus(opraSync.status?.status)"></div>
       </div>
       <span class="badge" :class="opraSyncBadgeClass()" x-text="opraSyncBadgeText()"></span>
     </div>
     <div class="info-row" style="margin-top: 12px;">
-      <div class="muted">Current Commit</div>
-      <div class="mono" x-text="opraSync.status?.current_commit || '—'"></div>
+      <div class="muted">{{ t('label_current_commit') }}</div>
+      <div class="mono" x-text="opraSync.status?.current_commit || t('text_dash')"></div>
     </div>
     <div class="info-row">
-      <div class="muted">Previous Commit</div>
-      <div class="mono" x-text="opraSync.status?.previous_commit || '—'"></div>
+      <div class="muted">{{ t('label_previous_commit') }}</div>
+      <div class="mono" x-text="opraSync.status?.previous_commit || t('text_dash')"></div>
     </div>
     <div class="info-row">
-      <div class="muted">Downloaded At</div>
+      <div class="muted">{{ t('label_downloaded_at') }}</div>
       <div class="mono" x-text="formatIso(opraSync.status?.current_metadata?.downloaded_at)"></div>
     </div>
     <div class="info-row" x-show="opraSync.status?.last_error">
-      <div class="muted">Last Error</div>
+      <div class="muted">{{ t('label_last_error') }}</div>
       <div class="mono" x-text="opraSync.status?.last_error"></div>
     </div>
 
-    {{ forms.text_input('opraSyncTarget', 'Source / Target', 'opraSync.targetRef', placeholder='latest or commit SHA', disabled='opraSync.loading || opraSync.status?.status === \"running\"') }}
+    {{ forms.text_input('opraSyncTarget', t('label_source_target'), 'opraSync.targetRef', placeholder=t('placeholder_latest_or_sha'), disabled='opraSync.loading || opraSync.status?.status === \"running\"') }}
 
     <div class="profile-actions">
-      {{ buttons.btn_primary('Check Updates', click='checkOpraAvailable()', disabled='opraSync.loading') }}
-      {{ buttons.btn_primary('Update', click='startOpraUpdate()', disabled='opraSync.loading || opraSync.status?.status === \"running\"') }}
-      {{ buttons.btn_primary('Rollback', click='startOpraRollback()', disabled='opraSync.loading || opraSync.status?.status === \"running\" || !opraSync.status?.previous_commit', extra_class='btn-secondary') }}
+      {{ buttons.btn_primary(t('btn_check_updates'), click='checkOpraAvailable()', disabled='opraSync.loading') }}
+      {{ buttons.btn_primary(t('btn_update'), click='startOpraUpdate()', disabled='opraSync.loading || opraSync.status?.status === \"running\"') }}
+      {{ buttons.btn_primary(t('btn_rollback'), click='startOpraRollback()', disabled='opraSync.loading || opraSync.status?.status === \"running\" || !opraSync.status?.previous_commit', extra_class='btn-secondary') }}
     </div>
 
     <div class="notice success" x-show="opraSync.message" x-text="opraSync.message" style="margin-top: 16px;"></div>
@@ -289,7 +289,7 @@ function eqApp() {
     },
     formatIso(isoString) {
       if (!isoString) {
-        return '—';
+        return t('text_dash');
       }
       try {
         return new Date(isoString).toLocaleString();
@@ -299,10 +299,10 @@ function eqApp() {
     },
     formatOpraStatus(status) {
       const normalized = String(status || 'idle').toLowerCase();
-      if (normalized === 'running') return 'Running';
-      if (normalized === 'ready') return 'Ready';
-      if (normalized === 'failed') return 'Failed';
-      return 'Idle';
+      if (normalized === 'running') return t('opra_status_running');
+      if (normalized === 'ready') return t('opra_status_ready');
+      if (normalized === 'failed') return t('opra_status_failed');
+      return t('opra_status_idle');
     },
     opraSyncBadgeClass() {
       const normalized = String(this.opraSync.status?.status || 'idle').toLowerCase();
@@ -312,10 +312,10 @@ function eqApp() {
     },
     opraSyncBadgeText() {
       const normalized = String(this.opraSync.status?.status || 'idle').toLowerCase();
-      if (normalized === 'running') return 'RUNNING';
-      if (normalized === 'ready') return 'READY';
-      if (normalized === 'failed') return 'FAILED';
-      return 'IDLE';
+      if (normalized === 'running') return t('opra_badge_running');
+      if (normalized === 'ready') return t('opra_badge_ready');
+      if (normalized === 'failed') return t('opra_badge_failed');
+      return t('opra_badge_idle');
     },
     resolveOpraSyncParams() {
       const ref = String(this.opraSync.targetRef || '').trim();
@@ -354,12 +354,12 @@ function eqApp() {
         const response = await fetch(`/api/opra/sync/available?source=${encodeURIComponent(source)}`);
         const data = await response.json().catch(() => ({}));
         if (!response.ok) {
-          throw new Error(data.detail || data.message || 'Failed to check updates');
+          throw new Error(data.detail || data.message || t('error_failed_check_updates'));
         }
         this.opraSync.available = data;
-        this.opraSync.message = `Latest available: ${data.latest || 'unknown'}`;
+        this.opraSync.message = t('text_latest_available', { value: data.latest || t('label_unknown') });
       } catch (err) {
-        this.opraSync.error = err.message || 'Failed to check updates';
+        this.opraSync.error = err.message || t('error_failed_check_updates');
       } finally {
         this.opraSync.loading = false;
       }
@@ -369,7 +369,7 @@ function eqApp() {
         return;
       }
       const { source, target } = this.resolveOpraSyncParams();
-      if (!confirm(`Start OPRA update (${target})?`)) {
+      if (!confirm(t('confirm_start_opra_update', { target: target }))) {
         return;
       }
       this.opraSync.loading = true;
@@ -383,12 +383,12 @@ function eqApp() {
         });
         const data = await response.json().catch(() => ({}));
         if (!response.ok) {
-          throw new Error(data.detail || data.message || 'Failed to start update');
+          throw new Error(data.detail || data.message || t('error_failed_start_update'));
         }
-        this.opraSync.message = 'OPRA update started';
+        this.opraSync.message = t('message_opra_update_started');
         await this.fetchOpraSyncStatus();
       } catch (err) {
-        this.opraSync.error = err.message || 'Failed to start update';
+        this.opraSync.error = err.message || t('error_failed_start_update');
       } finally {
         this.opraSync.loading = false;
       }
@@ -397,7 +397,7 @@ function eqApp() {
       if (this.opraSync.loading) {
         return;
       }
-      if (!confirm('Rollback OPRA database to previous version?')) {
+      if (!confirm(t('confirm_opra_rollback'))) {
         return;
       }
       this.opraSync.loading = true;
@@ -407,12 +407,12 @@ function eqApp() {
         const response = await fetch('/api/opra/sync/rollback', { method: 'POST' });
         const data = await response.json().catch(() => ({}));
         if (!response.ok) {
-          throw new Error(data.detail || data.message || 'Failed to start rollback');
+          throw new Error(data.detail || data.message || t('error_failed_start_rollback'));
         }
-        this.opraSync.message = 'OPRA rollback started';
+        this.opraSync.message = t('message_opra_rollback_started');
         await this.fetchOpraSyncStatus();
       } catch (err) {
-        this.opraSync.error = err.message || 'Failed to start rollback';
+        this.opraSync.error = err.message || t('error_failed_start_rollback');
       } finally {
         this.opraSync.loading = false;
       }
@@ -427,7 +427,7 @@ function eqApp() {
       try {
         const response = await fetch(`/opra/search?q=${encodeURIComponent(this.opra.searchQuery)}`);
         if (!response.ok) {
-          throw new Error('Search failed');
+          throw new Error(t('error_search_failed'));
         }
         const data = await response.json();
         this.opra.results = data.results || [];
@@ -456,23 +456,23 @@ function eqApp() {
       try {
         const eqId = this.opra.selectedEqId || this.opra.eqProfiles[0]?.id;
         if (!eqId) {
-          throw new Error('No EQ profile selected');
+          throw new Error(t('error_no_eq_profile_selected'));
         }
 
         const endpoint = `/opra/apply/${encodeURIComponent(eqId)}?apply_correction=${this.opra.useModernTarget}`;
         const response = await fetch(endpoint, { method: 'POST' });
         if (!response.ok) {
           const err = await response.json();
-          throw new Error(err.detail || 'Failed to apply OPRA EQ');
+          throw new Error(err.detail || t('error_failed_apply_opra'));
         }
 
         const data = await response.json();
-        this.opraMessage = data.message || 'OPRA EQ applied';
+        this.opraMessage = data.message || t('message_opra_eq_applied');
         await this.fetchActive();
         await this.fetchProfiles();
       } catch (error) {
         console.error('Failed to apply OPRA EQ:', error);
-        this.opraError = error.message || 'Failed to apply OPRA EQ';
+        this.opraError = error.message || t('error_failed_apply_opra');
       } finally {
         this.opraActionPending = false;
       }
@@ -503,7 +503,7 @@ function eqApp() {
       const response = await fetch('/api/eq/import', { method: 'POST', body: formData });
       if (!response.ok) {
         const err = await response.json();
-        this.validation = { valid: false, errors: [err.detail || 'Upload failed'], warnings: [] };
+        this.validation = { valid: false, errors: [err.detail || t('error_upload_failed')], warnings: [] };
         return;
       }
       const data = await response.json();
@@ -527,13 +527,13 @@ function eqApp() {
     },
     formatRate(rate) {
       if (!rate || rate <= 0) {
-        return '—';
+        return t('text_dash');
       }
-      return `${rate} Hz`;
+      return `${rate} ${t('unit_hz')}`;
     },
     formatUptime(ms) {
       if (ms === null || ms === undefined) {
-        return '—';
+        return t('text_dash');
       }
       const seconds = Math.floor(ms / 1000);
       const minutes = Math.floor(seconds / 60);
@@ -541,12 +541,12 @@ function eqApp() {
       const remMinutes = minutes % 60;
       const remSeconds = seconds % 60;
       if (hours > 0) {
-        return `${hours}h ${remMinutes}m`;
+        return `${hours}${t('unit_hour_short')} ${remMinutes}${t('unit_minute_short')}`;
       }
       if (minutes > 0) {
-        return `${minutes}m ${remSeconds}s`;
+        return `${minutes}${t('unit_minute_short')} ${remSeconds}${t('unit_second_short')}`;
       }
-      return `${remSeconds}s`;
+      return `${remSeconds}${t('unit_second_short')}`;
     },
     async setPhase(phase) {
       this.actionPending = true;
@@ -560,11 +560,11 @@ function eqApp() {
         });
         if (!response.ok) {
           const err = await response.json();
-          this.actionError = err.detail || 'Phase update failed';
+          this.actionError = err.detail || t('error_phase_update_failed');
           return;
         }
         const data = await response.json();
-        this.actionMessage = data.message || 'Phase updated';
+        this.actionMessage = data.message || t('message_phase_updated');
         this.phaseType = phase;
         await this.fetchStatus();
       } finally {
@@ -572,10 +572,10 @@ function eqApp() {
       }
     },
     async requestReload() {
-      await this.runDaemonAction('/api/daemon/reload', 'Reload requested');
+      await this.runDaemonAction('/api/daemon/reload', t('message_reload_requested'));
     },
     async requestSoftReset() {
-      await this.runDaemonAction('/api/daemon/soft-reset', 'Soft reset requested');
+      await this.runDaemonAction('/api/daemon/soft-reset', t('message_soft_reset_requested'));
     },
     async runDaemonAction(url, successMessage) {
       this.actionPending = true;
@@ -585,7 +585,7 @@ function eqApp() {
         const response = await fetch(url, { method: 'POST' });
         if (!response.ok) {
           const err = await response.json();
-          this.actionError = err.detail || 'Command failed';
+          this.actionError = err.detail || t('error_command_failed');
           return;
         }
         this.actionMessage = successMessage;

--- a/web/templates/pages/settings.html
+++ b/web/templates/pages/settings.html
@@ -6,39 +6,39 @@
 {% block content %}
 <div x-data="alsaSettingsApp()" x-init="init()">
   <header class="page-header">
-    <h1 class="page-title">ALSA Device Settings</h1>
-    <p class="page-subtitle">Select capture/playback devices and persist settings.</p>
+    <h1 class="page-title">{{ t('alsa_page_title') }}</h1>
+    <p class="page-subtitle">{{ t('alsa_page_subtitle') }}</p>
   </header>
 
   <div class="grid grid-2">
-    {% call panels.card_panel("Device Selection") %}
-      {{ forms.select_input('alsaInput', 'Input Device', 'config.alsa.input_device', 'devices.capture') }}
-      {{ forms.select_input('alsaOutput', 'Output Device', 'config.alsa.output_device', 'devices.playback') }}
+    {% call panels.card_panel(t('section_device_selection')) %}
+      {{ forms.select_input('alsaInput', t('label_input_device'), 'config.alsa.input_device', 'devices.capture') }}
+      {{ forms.select_input('alsaOutput', t('label_output_device'), 'config.alsa.output_device', 'devices.playback') }}
       <div class="notice" x-show="!devices.capture.length || !devices.playback.length">
-        Device list is empty or unavailable. Ensure the DSP daemon is running.
+        {{ t('notice_devices_empty') }}
       </div>
     {% endcall %}
 
-    {% call panels.card_panel("Stream Parameters") %}
-      {{ forms.text_input('alsaRate', 'Sample Rate (Hz)', 'config.alsa.sample_rate', type='number', placeholder='Auto') }}
-      {{ forms.text_input('alsaChannels', 'Channels', 'config.alsa.channels', type='number', placeholder='2') }}
-      {{ forms.select_input('alsaFormat', 'Format', 'config.alsa.format', 'formatOptions') }}
-      {{ forms.text_input('alsaPeriod', 'Period Frames', 'config.alsa.period_frames', type='number', placeholder='Auto') }}
-      {{ forms.text_input('alsaBuffer', 'Buffer Frames', 'config.alsa.buffer_frames', type='number', placeholder='Auto') }}
+    {% call panels.card_panel(t('section_stream_parameters')) %}
+      {{ forms.text_input('alsaRate', t('label_sample_rate'), 'config.alsa.sample_rate', type='number', placeholder=t('placeholder_auto')) }}
+      {{ forms.text_input('alsaChannels', t('label_channels'), 'config.alsa.channels', type='number', placeholder=t('placeholder_channels_default')) }}
+      {{ forms.select_input('alsaFormat', t('label_format'), 'config.alsa.format', 'formatOptions') }}
+      {{ forms.text_input('alsaPeriod', t('label_period_frames'), 'config.alsa.period_frames', type='number', placeholder=t('placeholder_auto')) }}
+      {{ forms.text_input('alsaBuffer', t('label_buffer_frames'), 'config.alsa.buffer_frames', type='number', placeholder=t('placeholder_auto')) }}
     {% endcall %}
 
-    {% call panels.card_panel("Filter Settings") %}
-      {{ forms.select_input('filterRatio', 'Upsample Ratio', 'config.filter.ratio', 'ratioOptions') }}
-      {{ forms.select_input('filterPhase', 'Phase Type', 'config.filter.phase_type', 'phaseOptions') }}
-      {{ forms.text_input('filterDir', 'Filter Directory', 'config.filter.directory', placeholder='/opt/totton-dsp/data/coefficients') }}
+    {% call panels.card_panel(t('section_filter_settings')) %}
+      {{ forms.select_input('filterRatio', t('label_upsample_ratio'), 'config.filter.ratio', 'ratioOptions') }}
+      {{ forms.select_input('filterPhase', t('label_phase_type'), 'config.filter.phase_type', 'phaseOptions') }}
+      {{ forms.text_input('filterDir', t('label_filter_directory'), 'config.filter.directory', placeholder=t('placeholder_filter_directory')) }}
     {% endcall %}
   </div>
 
-  {% call panels.card_panel("Apply Settings") %}
+  {% call panels.card_panel(t('section_apply_settings')) %}
     <div class="profile-actions">
-      {{ buttons.btn_primary('Save & Apply', click='saveConfig()', disabled='actionPending') }}
-      {{ buttons.btn_primary('Reload Devices', click='fetchDevices()', disabled='actionPending', extra_class='btn-secondary') }}
-      {{ buttons.btn_primary('Refresh Config', click='fetchConfig()', disabled='actionPending', extra_class='btn-secondary') }}
+      {{ buttons.btn_primary(t('btn_save_apply'), click='saveConfig()', disabled='actionPending') }}
+      {{ buttons.btn_primary(t('btn_reload_devices'), click='fetchDevices()', disabled='actionPending', extra_class='btn-secondary') }}
+      {{ buttons.btn_primary(t('btn_refresh_config'), click='fetchConfig()', disabled='actionPending', extra_class='btn-secondary') }}
     </div>
     <div class="notice success" x-show="actionMessage" x-text="actionMessage" style="margin-top: 16px;"></div>
     <div class="notice error" x-show="actionError" x-text="actionError" style="margin-top: 16px;"></div>
@@ -67,15 +67,15 @@ function alsaSettingsApp() {
       }
     },
     ratioOptions: [
-      { label: '1x (Bypass)', value: 1 },
-      { label: '2x', value: 2 },
-      { label: '4x', value: 4 },
-      { label: '8x', value: 8 },
-      { label: '16x', value: 16 }
+      { label: t('ratio_1x_bypass'), value: 1 },
+      { label: t('ratio_2x'), value: 2 },
+      { label: t('ratio_4x'), value: 4 },
+      { label: t('ratio_8x'), value: 8 },
+      { label: t('ratio_16x'), value: 16 }
     ],
     phaseOptions: [
-      { label: 'Minimum', value: 'minimum' },
-      { label: 'Linear', value: 'linear' }
+      { label: t('phase_minimum'), value: 'minimum' },
+      { label: t('phase_linear'), value: 'linear' }
     ],
     actionPending: false,
     actionMessage: null,
@@ -88,7 +88,7 @@ function alsaSettingsApp() {
       try {
         const response = await fetch('/api/alsa/devices');
         if (!response.ok) {
-          throw new Error('Failed to load devices');
+          throw new Error(t('error_failed_load_devices'));
         }
         const data = await response.json();
         this.devices.playback = data.playback || [];
@@ -101,7 +101,7 @@ function alsaSettingsApp() {
       try {
         const response = await fetch('/api/config');
         if (!response.ok) {
-          throw new Error('Failed to load config');
+          throw new Error(t('error_failed_load_config'));
         }
         const data = await response.json();
         const settings = data.settings || {};
@@ -149,13 +149,13 @@ function alsaSettingsApp() {
         });
         if (!response.ok) {
           const err = await response.json();
-          throw new Error(err.detail || 'Failed to save config');
+          throw new Error(err.detail || t('error_failed_save_config'));
         }
         const data = await response.json();
         if (data.restart_required) {
-          this.actionMessage = 'Saved. Restart required to apply ALSA changes.';
+          this.actionMessage = t('message_saved_restart_required');
         } else {
-          this.actionMessage = 'Saved and applied.';
+          this.actionMessage = t('message_saved_applied');
         }
       } catch (err) {
         this.actionError = err.message;


### PR DESCRIPTION
## Summary
- i18n用の翻訳辞書とテンプレートコンテキストを追加
- JinjaテンプレートとUIメッセージを翻訳キー経由に置換
- JS向けの翻訳ヘルパーと文字列を整備

## Testing
- Prepare build directory
- Build & ctest
- Run diff-based tests
- Run local file E2E test
- Run Docker file E2E test
- ruff
- ruff-format