### PR TITLE
Fix #93: Vulkanリンクを伝播

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 
 if(ENABLE_VULKAN)
     find_package(Vulkan REQUIRED)
-    target_compile_definitions(vulkan_upsampler PRIVATE ENABLE_VULKAN=1)
-    target_link_libraries(vulkan_upsampler PRIVATE Vulkan::Vulkan)
+    target_compile_definitions(vulkan_upsampler PUBLIC ENABLE_VULKAN=1)
+    target_link_libraries(vulkan_upsampler PUBLIC Vulkan::Vulkan)
 
     if(USE_VKFFT)
         include(FetchContent)


### PR DESCRIPTION
## 概要\n- Vulkan依存を静的ライブラリから実行ファイルに伝播するため、vulkan_upsamplerのリンク指定をPUBLICに変更\n\n## 影響\n- alsa_streamerがVulkanランタイムにリンクされ、GPUアクセラレーションが有効化される\n\n## テスト\n- pre-pushフック内のBuild & ctest/差分テスト/E2Eが成功\n