### PR TITLE
Fix #103: upgrade run-on-arch-action to v3

### DIFF
--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build (arm64)
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v3
         with:
           arch: aarch64
           distro: ubuntu24.04


### PR DESCRIPTION
## Summary
- Upgrade `uraimo/run-on-arch-action` from v2 to v3
- Fixes CI/CD failure caused by Ubuntu 24.04 unsupported in v2

## Background
PR #102 migrated to Ubuntu 24.04, but `run-on-arch-action@v2` does not support ubuntu24.04 distro, causing the following error:

```
Error: run-on-arch: Dockerfile.aarch64.ubuntu24.04 does not exist.
```

## Changes
- `.github/workflows/arm64-release.yml:22`: `@v2` → `@v3`

## Benefits of v3
- Official Ubuntu 24.04 support
- QEMU 9.2.2 upgrade (segfault fixes)
- More stable cross-compilation environment

## Testing
- [ ] GitHub Actions CI passes
- [ ] arm64 build completes successfully

## References
- https://github.com/uraimo/run-on-arch-action/releases/tag/v3.0.1

Closes #103