### PR TITLE
Fix #105: add glslang-tools package for Ubuntu 24.04

### DIFF
--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -31,6 +31,7 @@ jobs:
               cmake \
               git \
               glslang-dev \
+              glslang-tools \
               libasound2-dev \
               libvulkan-dev \
               libzmq3-dev \


### PR DESCRIPTION
## Summary
- Add `glslang-tools` package to arm64 build workflow
- Fixes CMake error when building on Ubuntu 24.04 arm64

## Background
After upgrading to `run-on-arch-action@v3` with Ubuntu 24.04 support (PR #104), the arm64 build fails with:

```
The imported target "glslang::glslang-standalone" references the file
   "/usr/bin/glslang"
but this file does not exist.
```

## Root Cause
Ubuntu 24.04 splits glslang into two packages:
- `glslang-dev`: Headers and libraries only
- `glslang-tools`: Executables (`/usr/bin/glslang`, `glslangValidator`)

CMake's `glslang-targets.cmake` requires the `/usr/bin/glslang` executable, which is only provided by `glslang-tools`.

## Changes
- `.github/workflows/arm64-release.yml:34`: Add `glslang-tools` package

## Testing
- [ ] GitHub Actions arm64 build completes successfully
- [ ] CMake finds glslang executable without errors
- [ ] VkFFT-based Vulkan components build correctly

## References
- Related: PR #104 (run-on-arch-action v3 upgrade)
- Issue: #105

Closes #105