### PR TITLE
#111 ALSA XRUN: 出力バッファのスケール

### DIFF
--- a/src/alsa/alsa_streamer_main.cpp
+++ b/src/alsa/alsa_streamer_main.cpp
@@ -443,9 +443,14 @@ int main(int argc, char **argv) {
 
   const auto outputFrames =
       static_cast<size_t>(capture->periodFrames) * upsampleFactor;
+  const snd_pcm_uframes_t outputBufferFrames =
+      (options.bufferFrames > 0)
+          ? static_cast<snd_pcm_uframes_t>(options.bufferFrames) *
+                upsampleFactor
+          : 0;
   auto playback = totton::alsa::OpenPcm(
       options.outputDevice, SND_PCM_STREAM_PLAYBACK, format, options.channels,
-      outputRate, outputFrames, options.bufferFrames);
+      outputRate, outputFrames, outputBufferFrames);
   if (!playback) {
     return 1;
   }


### PR DESCRIPTION
## Summary
- アップサンプリング倍率に合わせて playback の bufferFrames をスケール
- output period > buffer の不整合を解消

## Testing
- pre-commit run --hook-stage pre-push