### PR TITLE
Fix #113: 音飛び問題

### DIFF
--- a/src/vulkan/vulkan_streaming_upsampler.cpp
+++ b/src/vulkan/vulkan_streaming_upsampler.cpp
@@ -96,16 +96,16 @@ namespace {
 
 std::string DeviceTypeLabel(VkPhysicalDeviceType type) {
   switch (type) {
-    case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
-      return "discrete";
-    case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
-      return "integrated";
-    case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
-      return "virtual";
-    case VK_PHYSICAL_DEVICE_TYPE_CPU:
-      return "cpu";
-    default:
-      return "other";
+  case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+    return "discrete";
+  case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+    return "integrated";
+  case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+    return "virtual";
+  case VK_PHYSICAL_DEVICE_TYPE_CPU:
+    return "cpu";
+  default:
+    return "other";
   }
 }
 
@@ -129,18 +129,18 @@ bool FindComputeQueueFamily(VkPhysicalDevice device, uint32_t *index) {
 
 int DeviceTypeRank(VkPhysicalDeviceType type) {
   switch (type) {
-    case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
-      return 0;
-    case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
-      return 1;
-    case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
-      return 2;
-    case VK_PHYSICAL_DEVICE_TYPE_OTHER:
-      return 3;
-    case VK_PHYSICAL_DEVICE_TYPE_CPU:
-      return 4;
-    default:
-      return 5;
+  case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+    return 0;
+  case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+    return 1;
+  case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+    return 2;
+  case VK_PHYSICAL_DEVICE_TYPE_OTHER:
+    return 3;
+  case VK_PHYSICAL_DEVICE_TYPE_CPU:
+    return 4;
+  default:
+    return 5;
   }
 }
 


### PR DESCRIPTION
## 概要
- Vulkan 物理デバイス選択を GPU 優先に変更
- 選択デバイスのログを追加して CPU/LVP 選択を判別可能に

## 変更点
- compute queue を持つデバイスを列挙し、discrete/integrated を優先
- 選択されたデバイス名と種別を stderr に出力

## テスト
- pre-push フック一式（Build & ctest / diff-based tests / local file E2E / Docker file E2E / clang-format / clang-tidy）